### PR TITLE
Fix deprecated spec ordering

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'default'
+  config.order = :random
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,5 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random
+  config.order = :defined
 end


### PR DESCRIPTION
This pull request makes a minor change to the RSpec configuration in `spec/spec_helper.rb`, switching the test execution order from default to defined to help surface order dependencies in the test suite.